### PR TITLE
Updated docs version

### DIFF
--- a/docs/antora.yml
+++ b/docs/antora.yml
@@ -1,6 +1,6 @@
 name: substrate-runtimes
 title: Substrate Runtimes
-version: 0.1.0
+version: 1.0.0
 nav:
   - modules/ROOT/nav.adoc
 asciidoc:


### PR DESCRIPTION
During the release preparation we forgot to update the docs version.
We do not need it under the release tag, it is needed only for the correct representation on docs website.