### PR TITLE
Remove security warning from docs and fix style in list

### DIFF
--- a/docs/modules/ROOT/pages/index.adoc
+++ b/docs/modules/ROOT/pages/index.adoc
@@ -5,8 +5,6 @@
 
 A collection of runtimes that describe parachains with different purposes.
 
-IMPORTANT: This repo contains code in its early stages. Please be aware that it may change rapidly and is not yet audited.
-
 == Quick start
 
 * Begin by visiting our link:https://github.com/OpenZeppelin/polkadot-runtime-template[repository]. You can fork it, use it as a template, or simply clone it to your local directory.

--- a/docs/modules/ROOT/pages/runtimes/generic.adoc
+++ b/docs/modules/ROOT/pages/runtimes/generic.adoc
@@ -16,10 +16,11 @@ We designed this template to be generic, so that it can be used as a starting po
 and we aim to base our future templates off of this one.
 
 To demystify the hard concepts, we provided a documentation, in which you can find:
-* explanation of the pallets that are used in this template (purpose, terminology, configuration, dispatchables, etc.),
-* general guides regarding this template,
-* runtime related guides,
-* and miscellaneous topics.
+
+* Explanation of the pallets that are used in this template (purpose, terminology, configuration, dispatchables, etc.).
+* General guides regarding this template.
+* Runtime related guides.
+* And miscellaneous topics.
 
 == Configuration
 


### PR DESCRIPTION
Fixes #177 

- Remove security warning from docs after the audit and since release v1.0.0 is ready
- Fix list formatting issue

#### PR Checklist
- [x] Documentation
