### PR TITLE
Update index.adoc - fix chainspec generation command

### DIFF
--- a/docs/modules/ROOT/pages/index.adoc
+++ b/docs/modules/ROOT/pages/index.adoc
@@ -33,7 +33,7 @@ cargo build --release
 ** Generate a plain chainspec with this command:
 +
 ```bash
-./target/release/parachain-template-node build-spec --disable-default-nodes > plain-parachain-chainspec.json
+./target/release/parachain-template-node build-spec --disable-default-bootnode > plain-parachain-chainspec.json
 ```
 
 ** Edit the chainspec:


### PR DESCRIPTION
` --disable-default-nodes` does not exist. Perhaps, the intent was to use `--disable-default-bootnode`.

